### PR TITLE
remove old broken IE8 polyfill

### DIFF
--- a/sample/demo-balance-text.htm
+++ b/sample/demo-balance-text.htm
@@ -10,10 +10,6 @@
   balanceText();
 </script>
 <link rel="stylesheet" type="text/css" href="main.css">
-<!--[if lt IE 9]>
-<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
-
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */
 .balance-text {


### PR DESCRIPTION
This no longer works since Google Code has closed and not needed

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
