### PR TITLE
Edit container height calculation

### DIFF
--- a/balancetext.js
+++ b/balancetext.js
@@ -534,6 +534,7 @@
 
             // remove line height before measuring container size
             el.style.lineHeight = "normal";
+            el.style.display = "inline";
 
             const containerWidth = el.offsetWidth;
             const containerHeight = el.offsetHeight;
@@ -541,7 +542,6 @@
             // temporary settings
             el.style.whiteSpace = "nowrap";
             el.style.float = "none";
-            el.style.display = "inline";
             el.style.position = "static";
 
             let nowrapWidth = el.offsetWidth;


### PR DESCRIPTION
## Description

Edit so that both `containerHeight` and `nowrapHeight` calculations now utilize inline display, which _I think_ results in a more accurate `totLines` (saw a need for this in text ~3–4 lines long). Might be mistaken however, but I found it fixes issues I was seeing where total line count was jumping unnecessarily high.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). ->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
